### PR TITLE
temporary docs fix: remove mention of PySpark, point R to contrib

### DIFF
--- a/api-r.md
+++ b/api-r.md
@@ -1,3 +1,3 @@
-R support is in active development. Please [contact us](mailto:feedback@quiltdata.io) if you'd like to contribute.
+R support has been graciously contributed by the community on [GitHub](https://github.com/stillmatic/quiltr)
 
 ***

--- a/supported-languages.md
+++ b/supported-languages.md
@@ -4,10 +4,10 @@
 * 3.5
 * 3.6
 
-# PySpark
-* See here
+# R
+* Community contribution on [GitHub](https://github.com/stillmatic/quiltr).
 
-# R, Scala
-* Planned. We welcome your  contributions on [GitHub](https://github.com/quiltdata/quilt).
+Scala
+* Planned. We welcome your contributions on [GitHub](https://github.com/quiltdata/quilt).
 
 ***


### PR DESCRIPTION
I'd like to "put out the fire" of embarrassing docs, then we can "do it right" with less urgency.

