### PR TITLE
Fix import of uciml/wine

### DIFF
--- a/edit-a-package.md
+++ b/edit-a-package.md
@@ -3,7 +3,7 @@ Start by installing and importing the package you wish to modify:
 ``` python
 import quilt
 quilt.install("uciml/wine")
-from quilt.data.akarve import wine
+from quilt.data.uciml import wine
 ```
 
 # New package


### PR DESCRIPTION
Our docs had a lingering reference to the now-non-existent package
akarve/wine.